### PR TITLE
fix importing vue components namespaces

### DIFF
--- a/resources/assets/js/panel/Components/FormInputGroup.vue
+++ b/resources/assets/js/panel/Components/FormInputGroup.vue
@@ -24,10 +24,10 @@
 </template>
 
 <script>
-import Label from '@/components/Label'
-import Input from '@/components/Input'
-import FormErrorText from '@/components/FormErrorText'
-import FormHelperText from '@/components/FormHelperText'
+import Label from '@/Components/Label'
+import Input from '@/Components/Input'
+import FormErrorText from '@/Components/FormErrorText'
+import FormHelperText from '@/Components/FormHelperText'
 
 export default {
     inheritAttrs: false,

--- a/resources/assets/js/panel/Components/FormTextareaGroup.vue
+++ b/resources/assets/js/panel/Components/FormTextareaGroup.vue
@@ -24,10 +24,10 @@
 </template>
 
 <script>
-import Label from '@/components/Label'
-import Textarea from '@/components/Textarea'
-import FormErrorText from '@/components/FormErrorText'
-import FormHelperText from '@/components/FormHelperText'
+import Label from '@/Components/Label'
+import Textarea from '@/Components/Textarea'
+import FormErrorText from '@/Components/FormErrorText'
+import FormHelperText from '@/Components/FormHelperText'
 
 export default {
     inheritAttrs: false,


### PR DESCRIPTION
When running `npm run watch` or `npm run dev`
I got those errors

ERROR  Failed to compile with 4 errors                                                                                            

 error  in ./resources/assets/js/panel/Components/FormTextareaGroup.vue?vue&type=script&lang=js

Module not found: Error: Can't resolve '@/components/Label' in '/var/www/html/larabug-app/resources/assets/js/panel/Components'

 error  in ./resources/assets/js/panel/Components/FormTextareaGroup.vue?vue&type=script&lang=js

Module not found: Error: Can't resolve '@/components/Textarea' in '/var/www/html/larabug-app/resources/assets/js/panel/Components'

 error  in ./resources/assets/js/panel/Components/FormTextareaGroup.vue?vue&type=script&lang=js

Module not found: Error: Can't resolve '@/components/FormErrorText' in '/var/www/html/larabug-app/resources/assets/js/panel/Components'

 error  in ./resources/assets/js/panel/Components/FormTextareaGroup.vue?vue&type=script&lang=js

Module not found: Error: Can't resolve '@/components/FormHelperText' in '/var/www/html/larabug-app/resources/assets/js/panel/Components'

This pull request fixes it