### PR TITLE
Fix javascript exception

### DIFF
--- a/app/Notifications/ExceptionWasCreated.php
+++ b/app/Notifications/ExceptionWasCreated.php
@@ -92,7 +92,7 @@ class ExceptionWasCreated extends Notification implements ShouldQueue
                     'fields' => [
                         [
                             'name' => 'Class',
-                            'value' => $this->exception->class,
+                            'value' => $this->exception->class ?? 'no value',
                             'inline' => true
                         ],
                         [

--- a/resources/views/frontend/exception.blade.php
+++ b/resources/views/frontend/exception.blade.php
@@ -41,7 +41,7 @@
 
         <article class="w-full max-w-6xl mx-auto px-4 text-center">
             <pre class="{{ $exception->markup_language }} line-numbers"
-                 data-start="{{ $exception->executor[0]['line_number'] }}"
+                 data-start="{{ $exception->executor[0]['line_number'] ?? null }}"
                  data-line="{{ $exception->line }}"><code>{{ $exception->executor_output }}</code></pre>
         </article>
     </div>


### PR DESCRIPTION
We have an `Javascript` exception, and it seems there no value of it, so fix is by adding this

```php
$exception->executor[0]['line_number'] ?? null 
```

![Screenshot from 2021-06-04 17-40-30](https://user-images.githubusercontent.com/8251344/120781815-02d35700-c55c-11eb-9489-c615c9047b47.png)
![Screenshot from 2021-06-04 17-40-14](https://user-images.githubusercontent.com/8251344/120781827-049d1a80-c55c-11eb-8363-c6a5ee3cb7ea.png)

then this is the result when viewing share
![Screenshot from 2021-06-04 17-42-42](https://user-images.githubusercontent.com/8251344/120782124-475ef280-c55c-11eb-9aa9-a0a0f450d169.png)

Thank you