### PR TITLE
Add validation to projects custom webhook url

### DIFF
--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -25,7 +25,10 @@ class ProjectRequest extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required|max:255',
+            'title' => [
+                'required',
+                'max:255',
+            ],
             'description' => [
                 'nullable',
                 'max:500',
@@ -41,6 +44,10 @@ class ProjectRequest extends FormRequest
                 'nullable',
                 new StartsWith(['https://discordapp.com/api/webhooks/', 'https://discord.com/api/webhooks/'])
             ],
+            'custom_webhook' => [
+                'url',
+                'nullable'
+            ]
         ];
     }
 }


### PR DESCRIPTION
I think when creating or editing project custom webhook url should also have `url` and `nullable` validation rules