### PR TITLE
Call the `query` method in eloquent queries

### DIFF
--- a/app/Console/Commands/MailExceptions.php
+++ b/app/Console/Commands/MailExceptions.php
@@ -16,7 +16,7 @@ class MailExceptions extends Command
 
     public function handle()
     {
-        $users = User::where('receive_email', true)
+        $users = User::query()->where('receive_email', true)
             ->whereHas('projects', function ($query) {
                 return $query
                     ->where('notifications_enabled', true)

--- a/app/Filament/Widgets/StatsOverviewWidget.php
+++ b/app/Filament/Widgets/StatsOverviewWidget.php
@@ -27,7 +27,7 @@ class StatsOverviewWidget extends BaseWidget
     {
         $lastMonth = Carbon::now()->subMonth();
 
-        return Project::where('last_error_at', '>=', $lastMonth)->count();
+        return Project::query()->where('last_error_at', '>=', $lastMonth)->count();
     }
 
     protected function getExceptionGrowth(): int
@@ -55,16 +55,16 @@ class StatsOverviewWidget extends BaseWidget
 
     protected function getTotalExceptions(): int
     {
-        return Exception::count();
+        return Exception::query()->count();
     }
 
     protected function getTotalProjects(): int
     {
-        return Project::count();
+        return Project::query()->count();
     }
 
     protected function getTotalUsers(): int
     {
-        return User::count();
+        return User::query()->count();
     }
 }

--- a/app/Http/Controllers/Api/ExceptionController.php
+++ b/app/Http/Controllers/Api/ExceptionController.php
@@ -12,7 +12,7 @@ class ExceptionController extends Controller
     public function index(Request $request)
     {
         return ExceptionResource::collection(
-            Exception::whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())
+            Exception::query()->whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())
                 ->with('project:id,title')
                 ->latest('created_at')
                 ->limit(8)
@@ -22,7 +22,7 @@ class ExceptionController extends Controller
 
     public function show(Request $request, $exceptionId)
     {
-        $exception = Exception::whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())
+        $exception = Exception::query()->whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())
             ->findOrFail($exceptionId);
 
         if ($exception->status == Exception::OPEN) {
@@ -37,7 +37,7 @@ class ExceptionController extends Controller
     {
         $projects = $request->user()->projects()->get(['id'])->pluck('id')->toArray();
 
-        $exception = Exception::whereIn('project_id', $projects)
+        $exception = Exception::query()->whereIn('project_id', $projects)
             ->findOrFail($exceptionId);
 
         $exception->markAsRead();
@@ -52,7 +52,7 @@ class ExceptionController extends Controller
 
     public function togglePublic(Request $request, $exceptionId)
     {
-        $exception = Exception::whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())->findOrFail($exceptionId);
+        $exception = Exception::query()->whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())->findOrFail($exceptionId);
 
         if ($exception->publish_hash) {
             $exception->removePublic();
@@ -65,7 +65,7 @@ class ExceptionController extends Controller
 
     public function destroy(Request $request, $exceptionId)
     {
-        $exception = Exception::whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())
+        $exception = Exception::query()->whereIn('project_id', $request->user()->projects()->pluck('id')->toArray())
             ->findOrFail($exceptionId);
 
         $exception->delete();

--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -62,7 +62,7 @@ class ProjectController extends Controller
 
     public function store(ProjectRequest $request)
     {
-        $project = Project::create($request->only([
+        $project = Project::query()->create($request->only([
             'title',
             'description',
             'url',

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -95,7 +95,7 @@ class LoginController extends Controller
         }
 
         /* @var $socialUser \App\Models\SocialUser */
-        $socialUser = SocialUser::where('provider_id', $social->getId())
+        $socialUser = SocialUser::query()->where('provider_id', $social->getId())
             ->where('provider', $provider)
             ->first();
 
@@ -117,11 +117,11 @@ class LoginController extends Controller
                 ]);
             }
 
-            $user = User::where('email', $social->getEmail())
+            $user = User::query()->where('email', $social->getEmail())
                 ->first();
 
             if (!$user) {
-                $user = User::create([
+                $user = User::query()->create([
                     'name' => $social->getName(),
                     'email' => $social->getEmail(),
                     'password' => str_random()

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -102,7 +102,7 @@ class RegisterController extends Controller
      */
     protected function create(array $data)
     {
-        return User::create([
+        return User::query()->create([
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => $data['password']

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -24,7 +24,7 @@ class FeedbackController extends Controller
 
     public function script(Request $request)
     {
-        $project = Project::whereHas('users', function ($query) {
+        $project = Project::query()->whereHas('users', function ($query) {
             return $query
                 ->where('project_user.owner', true);
         })

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -10,7 +10,7 @@ class HomeController extends Controller
     {
         $projects = auth()->user()->projects()->get(['id'])->pluck('id')->toArray();
 
-        $exceptions = Exception::whereIn('project_id', $projects)
+        $exceptions = Exception::query()->whereIn('project_id', $projects)
             ->with('project:id,title')
             ->latest('created_at')
             ->limit(8)
@@ -31,7 +31,7 @@ class HomeController extends Controller
         $totalExceptions = auth()->user()->projects()->sum('total_exceptions');
         $totalProjects = auth()->user()->projects()->count();
 
-        $exceptionChart = Exception::whereIn('project_id', $projects)
+        $exceptionChart = Exception::query()->whereIn('project_id', $projects)
             ->where('created_at', '>', now()->subDays(7))
             ->oldest()
             ->select(['created_at'])

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -34,7 +34,7 @@ class ProjectController extends Controller
 
     public function store(ProjectRequest $request)
     {
-        $project = Project::create($request->only([
+        $project = Project::query()->create($request->only([
             'title',
             'url',
             'description',

--- a/app/Models/Statistic.php
+++ b/app/Models/Statistic.php
@@ -12,12 +12,12 @@ class Statistic extends Model
 
     public static function getStatistics($key = 'total_exceptions')
     {
-        return self::first([$key])->{$key};
+        return self::query()->first([$key])->{$key};
     }
 
     public static function incrementStatistics($key = 'total_exceptions')
     {
-        $stats = self::first();
+        $stats = self::query()->first();
 
         $stats->{$key} ++;
         $stats->save();

--- a/app/Utilities/Stats.php
+++ b/app/Utilities/Stats.php
@@ -16,7 +16,7 @@ class Stats
      */
     public function exceptionGrowth()
     {
-        $exceptions = Exception::where('created_at', '>=', carbon()->subDays(30))
+        $exceptions = Exception::query()->where('created_at', '>=', carbon()->subDays(30))
             ->where('created_at', '<=', carbon())
             ->oldest()
             ->get();


### PR DESCRIPTION
Eloquent methods are recognized by IDEs and static analyzers, but if we call the `query` method first they will be ok.

![image](https://user-images.githubusercontent.com/6961695/176737639-69c6a342-0cc5-4809-ac5e-170b4020b230.png)
