### PR TITLE
Fix custom webhook request content-type header

### DIFF
--- a/app/Notifications/CustomWebhook/WebhookChannel.php
+++ b/app/Notifications/CustomWebhook/WebhookChannel.php
@@ -40,7 +40,7 @@ class WebhookChannel
 
         $response = $this->client->post($url, [
             'query' => Arr::get($webhookData, 'query'),
-            'body' => json_encode(Arr::get($webhookData, 'data')),
+            'json' => Arr::get($webhookData, 'data'),
             'verify' => Arr::get($webhookData, 'verify'),
             'headers' => Arr::get($webhookData, 'headers'),
         ]);


### PR DESCRIPTION
This PR relates to https://github.com/LaraBug/larabug-app/issues/114.

Using the `json` key instead of `body` for the guzzle request ensures the given data is json encoded and also applies the matching `content-type` header as mentioned in #114 
See [guzzle/guzzle Client.php](https://github.com/guzzle/guzzle/blob/master/src/Client.php#L374-L380)