### PR TITLE
Fixed Statistic buggy in exception page

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Models\Statistic;
 use Ramsey\Uuid\Uuid;
 use App\Models\Exception;
 use Illuminate\Support\Arr;
@@ -57,6 +58,8 @@ class ApiController extends Controller
             'user' => $request->input('user'),
             'project_version' => array_get($request->input('exception'), 'project_version'),
         ], $project, now()));
+
+        Statistic::incrementStatistics();
 
         return response([
             'id' => $id

--- a/app/Models/Statistic.php
+++ b/app/Models/Statistic.php
@@ -17,7 +17,9 @@ class Statistic extends Model
 
     public static function incrementStatistics($key = 'total_exceptions')
     {
-        $stats = self::query()->first();
+        $stats = self::query()
+            ->whereDate('created_at', now()->toDate())
+            ->firstOrCreate();
 
         $stats->{$key} ++;
         $stats->save();


### PR DESCRIPTION
Fix mark as fixed feature show exception caused by the statistic record not created yet, so i make statistic perday record, because we use this project to handle our multitenant so we might need to know how much exception we fixed in a day and how much exception recorded in a day, and in total how it fixed already. 